### PR TITLE
[maliit] Don't override the default surface format, extend it instead.

### DIFF
--- a/maliit-framework/src/quick/inputmethodquick.cpp
+++ b/maliit-framework/src/quick/inputmethodquick.cpp
@@ -41,7 +41,7 @@ QQuickView *createWindow(MAbstractInputMethodHost *host)
 {
     QScopedPointer<QQuickView> view(new QQuickView);
 
-    QSurfaceFormat format;
+    QSurfaceFormat format = view->requestedFormat();
     format.setAlphaBufferSize(8);
     view->setFormat(format);
     view->setColor(QColor(Qt::transparent));


### PR DESCRIPTION
This fixes warnings from the virtual keyboard about missing
depth and stencil buffers and potential rendering errors.
