### PR TITLE
Follow hw keyboard state

### DIFF
--- a/maliit-framework/src/mimhwkeyboardtracker.cpp
+++ b/maliit-framework/src/mimhwkeyboardtracker.cpp
@@ -45,11 +45,9 @@ MImHwKeyboardTrackerPrivate::MImHwKeyboardTrackerPrivate(MImHwKeyboardTracker *q
     present(false)
 {
 #ifdef HAVE_CONTEXTSUBSCRIBER
-    ContextProperty keyboardPresentProperty(keyboardPresent);
     keyboardOpenProperty.reset(new ContextProperty(keyboardOpen));
-    keyboardPresentProperty.waitForSubscription(true);
     keyboardOpenProperty->waitForSubscription(true);
-    present = keyboardPresentProperty.value().toBool();
+    present = true; // assume keyboard present as context property currently includes also external keyboards
     if (present) {
         QObject::connect(keyboardOpenProperty.data(), SIGNAL(valueChanged()),
                          q_ptr, SIGNAL(stateChanged()));

--- a/rpm/maliit-framework-wayland.spec
+++ b/rpm/maliit-framework-wayland.spec
@@ -20,6 +20,7 @@ BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  fdupes
 BuildRequires:  pkgconfig(qt5-boostable)
+BuildRequires:  pkgconfig(contextkit-statefs)
 Requires:   mapplauncherd-qt5
 Provides:   maliit-framework
 Conflicts:   maliit-framework-x11
@@ -91,7 +92,8 @@ pushd maliit-framework
     CONFIG+=enable-dbus-activation \
     CONFIG+=qt5-inputcontext \
     CONFIG+=lipstick \
-    CONFIG+=noxcb
+    CONFIG+=noxcb \
+    CONFIG+=enable-contextkit
 
 make %{?jobs:-j%jobs}
 popd


### PR DESCRIPTION
Using contextkit property /maemo/InternalKeyboard/Open, not fully sure if something better should be used instead.
